### PR TITLE
Work around git/go-git inconsistencies

### DIFF
--- a/pkg/releaser/importer.go
+++ b/pkg/releaser/importer.go
@@ -62,9 +62,17 @@ func importChart(cfg SrcConfiguration, src string) (chart.Chart, error) {
 
 	// checkout the default branch now and pull
 	wt, err := repo.Worktree()
+
 	wt.Checkout(&git.CheckoutOptions{
 		Branch: branch.Name(),
 	})
+	if err != nil {
+		logrus.Info(err)
+	}
+	err = wt.Reset(&git.ResetOptions{Mode: git.HardReset})
+	if err != nil {
+		logrus.Info(err)
+	}
 	err = wt.Pull(&git.PullOptions{})
 	if err != nil {
 		logrus.Info(err)
@@ -76,6 +84,10 @@ func importChart(cfg SrcConfiguration, src string) (chart.Chart, error) {
 	})
 	if err != nil {
 		logrus.Warn(err)
+	}
+	err = wt.Reset(&git.ResetOptions{Mode: git.HardReset})
+	if err != nil {
+		logrus.Info(err)
 	}
 
 	_, err = exec.Command("cp", "-LR", tempRepoDir+src, tempDir).Output()


### PR DESCRIPTION
It could happen that the repo got stuck with unstaged changes right after checkout. Tracking changes is irrelevant for us, so just hard resetting the repo after pull seems fine as a workaround. Underlying issue, i.e. how and why git and go-git differ here, wasn't investigated any further.