### PR TITLE
Use index.yaml instead of github releases to determine existing releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/tomwright/dasel v1.26.0
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.9.3
 )
 
@@ -110,9 +111,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
-	github.com/tidwall/gjson v1.14.2 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -133,7 +131,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.24.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/apimachinery v0.24.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -929,14 +929,6 @@ github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0
 github.com/tenntenn/modver v1.0.1/go.mod h1:bePIyQPb7UeioSRkw3Q0XeMhYZSMx9B8ePqg6SAMGH0=
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
-github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
-github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
-github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tklauser/go-sysconf v0.3.9/go.mod h1:11DU/5sG7UexIrp/O6g35hrWzu0JxlwQ3LSFUzyeuhs=
 github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -3,50 +3,36 @@ package releaser
 import (
 	"context"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-github/v36/github"
+	chartreleaserconfig "github.com/helm/chart-releaser/pkg/config"
+	chartreleasergit "github.com/helm/chart-releaser/pkg/git"
+	chartreleasergithub "github.com/helm/chart-releaser/pkg/github"
+	chartreleaser "github.com/helm/chart-releaser/pkg/releaser"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"os"
 	"path"
-	"strings"
-
-	chartreleaserconfig "github.com/helm/chart-releaser/pkg/config"
-	chartreleasergit "github.com/helm/chart-releaser/pkg/git"
-	chartreleasergithub "github.com/helm/chart-releaser/pkg/github"
-	chartreleaser "github.com/helm/chart-releaser/pkg/releaser"
 )
 
 func UpdateReleases(config Configuration, targetDir string, ghToken string) {
+	const pagesBranch = "gh-pages"
 	cwd, _ := os.Getwd()
 
 	destRepo := path.Join(cwd, "destrepo")
+	_ = os.RemoveAll(destRepo)
 	_ = os.MkdirAll(destRepo, 0700)
 	defer os.RemoveAll(destRepo)
 
 	logrus.Info("Cloning destrepo ", config.DstCfg.Owner, "/", config.DstCfg.Repo)
-	repo, err := git.PlainClone(destRepo, false, &git.CloneOptions{
-		URL:          "https://github.com/" + config.DstCfg.Owner + "/" + config.DstCfg.Repo,
-		SingleBranch: false,
+	_, err := git.PlainClone(destRepo, false, &git.CloneOptions{
+		URL:           "https://github.com/" + config.DstCfg.Owner + "/" + config.DstCfg.Repo,
+		ReferenceName: plumbing.NewBranchReferenceName(pagesBranch),
+		SingleBranch:  false,
 	})
 	if err != nil {
 		logrus.Error("Error during cloning of destination Repository: ", err)
-		return
-	}
-
-	// check whether the gh-pages branch is availabe on the remote side
-	// we need for the index.yaml
-	remote, _ := repo.Remote("origin")
-	rfs, _ := remote.List(&git.ListOptions{})
-	ghPagesExists := false
-	for _, r := range rfs {
-		if strings.Contains(string(r.Name()), "gh-pages") {
-			ghPagesExists = true
-			break
-		}
-	}
-	if ghPagesExists != true {
-		logrus.Error("I cannot go on, as the gh-pages branch is not existing in your destination repo: ", err)
 		return
 	}
 
@@ -58,9 +44,11 @@ func UpdateReleases(config Configuration, targetDir string, ghToken string) {
 	tokenClient := oauth2.NewClient(context.Background(), ts)
 	client := github.NewClient(tokenClient)
 
+	indexPath := path.Join(destRepo, "index.yaml")
+
 	// main loop over all items in the config file
 	for _, cfg := range config.SrcCfg {
-		versionsToRelease, _ := getReleasesToTrack(cfg, config.DstCfg, client)
+		versionsToRelease, _ := getReleasesToTrack(cfg, config.DstCfg, client, indexPath)
 		for _, v := range versionsToRelease {
 			cfg.Version = v.Original()
 			topLevelChart, err := getTopLevelChart(cfg, client)
@@ -77,9 +65,9 @@ func UpdateReleases(config Configuration, targetDir string, ghToken string) {
 		Owner:               config.DstCfg.Owner,
 		GitRepo:             config.DstCfg.Repo,
 		ChartsRepo:          config.DstCfg.Repo,
-		IndexPath:           path.Join(destRepo, "index.yaml"),
+		IndexPath:           indexPath,
 		PagesIndexPath:      "index.yaml",
-		PagesBranch:         "gh-pages",
+		PagesBranch:         pagesBranch,
 		Remote:              "origin",
 		PackagePath:         path.Join(cwd, targetDir),
 		Sign:                false,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -495,12 +495,6 @@ github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.3.0
 ## explicit; go 1.18
 github.com/subosito/gotenv
-# github.com/tidwall/gjson v1.14.2
-## explicit; go 1.12
-# github.com/tidwall/match v1.1.1
-## explicit; go 1.15
-# github.com/tidwall/pretty v1.2.0
-## explicit; go 1.16
 # github.com/tomwright/dasel v1.26.0
 ## explicit; go 1.17
 github.com/tomwright/dasel


### PR DESCRIPTION
Determining existing releases from github was brittle, being prone to rate-limiting issues. Using the existing index.yaml from gh-pages should be more reliable and flexible.